### PR TITLE
fix image thumbnail resizing

### DIFF
--- a/main.js
+++ b/main.js
@@ -222,7 +222,7 @@ async function processImage(srcPath) {
     for(const thumbType in thumbs) {
         const maxSize = thumbs[thumbType];
         let newPath = srcPath.replace(/\..+$/, '')+'-'+thumbType+'.jpg';
-        await executeCommand('magick', ['convert', srcPath, '-resize', maxSize+'<^', newPath]);
+        await executeCommand('magick', ['convert', srcPath, '-resize', `${maxSize}x${maxSize}^>`, newPath]);
         thumbs[thumbType] = newPath;
     }
     return thumbs;


### PR DESCRIPTION
Image conversion currently passes ImageMagick's enlarge-only flag, so normal photos produce full-resolution JPEGs for all three Synology thumbnail slots.

## What

Use square fill geometry with a shrink-only guard so SM, M, and XL derivatives use their intended short-edge sizes without upscaling small images.

## Validation

Built the project container and checked a 5712×4284 image: outputs changed from three 7.2 MB copies to 320×240 (24 KB), 427×320 (40 KB), and 1707×1280 (547 KB). A 100×75 source remained unchanged.
